### PR TITLE
#3

### DIFF
--- a/components/Navi.vue
+++ b/components/Navi.vue
@@ -18,6 +18,7 @@
       <v-toolbar-title>自由な出会いスペース</v-toolbar-title>
 
       <v-spacer></v-spacer>
+      {{ now }}
     </v-app-bar>
     <v-sheet
       id="scrolling-techniques-2"
@@ -28,3 +29,16 @@
     </v-sheet>
   </v-card>
 </template>
+
+<script>
+export default {
+  data() {
+    return {
+      now: null,
+    }
+  },
+  mounted() {
+    this.now = this.$dayjs().format('YYYY/MM/DD')
+  },
+}
+</script>

--- a/plugins/dayjs.js
+++ b/plugins/dayjs.js
@@ -2,6 +2,11 @@ import 'dayjs/locale/ja'
 import dayjs from 'dayjs'
 import Vue from 'vue'
 
+// day.jsをコンポーネント側から利用できるようにプラグイン化
+// nuxt.config.jsのプラグインにも記述追加
+// this.$dayjs().format('YYYY/MM/DD') のように利用可能
+// day.jsの動作については、各種ドキュメント参照 momentとあまり違いはない
+
 dayjs.locale('ja')
 
 Vue.prototype.$dayjs = dayjs


### PR DESCRIPTION
day.jsをコンポーネント側から利用できるようにプラグイン化
nuxt.config.jsのプラグインにも記述追加
this.$dayjs().format('YYYY/MM/DD') のように利用可能
day.jsの動作については、各種ドキュメント参照 momentとあまり違いはない
